### PR TITLE
Updating with 7.3.0 release

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,10 @@ the only supported platform is ``x86_64``.
 At the moment of writing, this image provide the following versions of
 PyPy:
 
+- PyPy2.7 7.3.0
+
+- PyPy3.6 7.3.0
+
 - PyPy2.7 7.2.0
 
 - PyPy3.6 7.2.0
@@ -41,38 +45,39 @@ also symlinked to ``/opt/python``. Moreover, each installation of PyPy
 contains also a ``python`` symlink.
 
 All the following commands are equivalent and run the PyPy 2.7, version
-7.1.1. You can use whatever fits best in your build system:
+7.3.0. You can use whatever fits best in your build system:
 
-- ``/opt/pypy/pypy2.7-7.1.1/bin/pypy``
+- ``/opt/pypy/pypy2.7-7.3.0/bin/pypy``
 
-- ``/opt/pypy/pypy2.7-7.1.1/bin/python``
+- ``/opt/pypy/pypy2.7-7.3.0/bin/python``
 
-- ``/opt/python/pp271-pypy_41/bin/pypy``
+- ``/opt/python/pp273-pypy_73/bin/pypy``
 
-- ``/opt/python/pp271-pypy_41/bin/python``
+- ``/opt/python/pp273-pypy_73/bin/python``
 
-Similarly, these are the commands to run PyPy 3.6, version 7.1.1:
+Similarly, these are the commands to run PyPy 3.6, version 7.3.0:
 
-- ``/opt/pypy/pypy3.6-7.1.1/bin/pypy``
+- ``/opt/pypy/pypy3.6-7.3.0/bin/pypy``
 
-- ``/opt/pypy/pypy3.6-7.1.1/bin/python``
+- ``/opt/pypy/pypy3.6-7.3.0/bin/python``
 
-- ``/opt/python/pp371-pypy3_71/bin/pypy``
+- ``/opt/python/pp373-pypy36_pp73/bin/pypy``
 
-- ``/opt/python/pp371-pypy3_71/bin/python``
+- ``/opt/python/pp373-pypy36_pp73/bin/python``
 
 
 PEP 425 Compatibility tags
 ---------------------------
 
-``pp271-pypy_41`` and ``pp371-pypy3_71`` are the `PEP 425`_ compliant
+``pp273-pypy_73`` and ``pp373-pypy36_pp73`` are the `PEP 425`_ compliant
 compatibility tag. In particular:
 
 - ``pp`` stands for PyPy (as opposed to ``cp`` which is CPython)
 
-- ``271`` and ``371`` mean "Python [2|3]", "PyPy 7.1.x".
+- ``273`` and ``373`` mean "Python [2|3]", "PyPy 7.3.x".
 
-- ``pypy_41`` and ``pypy3_71`` are the binary ABI tags for the relevant
-  version of PyPy. You can probably ignore them.
+- ``pypy_73`` and ``pypy36_pp73`` (or before PyPy 7.3.0, ``pypy_41`` and
+  ``pypy3_71``) are the binary ABI tags for the relevant version of PyPy.
+  You can probably ignore them.
 
 .. _`PEP 425`: https://www.python.org/dev/peps/pep-0425/

--- a/docker/build_scripts_pypy/install_pypy.sh
+++ b/docker/build_scripts_pypy/install_pypy.sh
@@ -18,6 +18,11 @@ function install_one_pypy {
     cd /opt/pypy
     tar xf $tarball
 
+    # the new PyPy 3 distributions don't have pypy symlinks to pypy3
+    if [ ! -f "$outdir/bin/pypy" ]; then
+        ln -s pypy3 $outdir/bin/pypy
+    fi
+
     # rename the directory to something shorter like pypy2.7-7.1.1
     shortdir=$(get_shortdir $outdir/bin/pypy)
     mv "$outdir" "$shortdir"

--- a/docker/build_scripts_pypy/prefetch_pypy.sh
+++ b/docker/build_scripts_pypy/prefetch_pypy.sh
@@ -22,6 +22,6 @@ fetch_source pypy3.6-7.1.1-beta-linux_x86_64-portable.tar.bz2 "$SQUEAKY_BITBUCKE
 fetch_source pypy-7.2.0-linux_x86_64-portable.tar.bz2 "$SQUEAKY_GITHUB_URL/pypy-7.2.0"
 fetch_source pypy3.6-7.2.0-linux_x86_64-portable.tar.bz2 "$SQUEAKY_GITHUB_URL/pypy3.6-7.2.0"
 
-# pypy 7.3.0rc3
-fetch_source pypy2.7-v7.3.0rc3-linux64.tar.bz2 "$URL"
-fetch_source pypy3.6-v7.3.0rc3-linux64.tar.bz2 "$URL"
+# pypy 7.3.0
+fetch_source pypy2.7-v7.3.0-linux64.tar.bz2 "$URL"
+fetch_source pypy3.6-v7.3.0-linux64.tar.bz2 "$URL"

--- a/docker/build_scripts_pypy/prefetch_pypy.sh
+++ b/docker/build_scripts_pypy/prefetch_pypy.sh
@@ -3,8 +3,10 @@
 set -ex
 
 SOURCES=docker/sources
-BITBUCKET_URL=https://bitbucket.org/squeaky/portable-pypy/downloads # old releases
-URL=https://github.com/squeaky-pl/portable-pypy/releases/download # new releases
+SQUEAKY_BITBUCKET_URL=https://bitbucket.org/squeaky/portable-pypy/downloads # older releases
+SQUEAKY_GITHUB_URL=https://github.com/squeaky-pl/portable-pypy/releases/download # old releases
+URL=https://bitbucket.org/pypy/pypy/downloads # new releases
+
 
 MY_DIR=$(dirname "${BASH_SOURCE[0]}")
 . $MY_DIR/../build_scripts/build_utils.sh
@@ -13,9 +15,13 @@ MY_DIR=$(dirname "${BASH_SOURCE[0]}")
 cd "$SOURCES"
 
 # pypy 7.1.1
-fetch_source pypy-7.1.1-linux_x86_64-portable.tar.bz2 "$BITBUCKET_URL"
-fetch_source pypy3.6-7.1.1-beta-linux_x86_64-portable.tar.bz2 "$BITBUCKET_URL"
+fetch_source pypy-7.1.1-linux_x86_64-portable.tar.bz2 "$SQUEAKY_BITBUCKET_URL"
+fetch_source pypy3.6-7.1.1-beta-linux_x86_64-portable.tar.bz2 "$SQUEAKY_BITBUCKET_URL"
 
 # pypy 7.2.0
-fetch_source pypy-7.2.0-linux_x86_64-portable.tar.bz2 "$URL/pypy-7.2.0"
-fetch_source pypy3.6-7.2.0-linux_x86_64-portable.tar.bz2 "$URL/pypy3.6-7.2.0"
+fetch_source pypy-7.2.0-linux_x86_64-portable.tar.bz2 "$SQUEAKY_GITHUB_URL/pypy-7.2.0"
+fetch_source pypy3.6-7.2.0-linux_x86_64-portable.tar.bz2 "$SQUEAKY_GITHUB_URL/pypy3.6-7.2.0"
+
+# pypy 7.3.0rc3
+fetch_source pypy2.7-v7.3.0rc3-linux64.tar.bz2 "$URL"
+fetch_source pypy3.6-v7.3.0rc3-linux64.tar.bz2 "$URL"


### PR DESCRIPTION
Temporary, locally-built test version available at https://hub.docker.com/r/yannickjadoul/manylinux2010-pypy_x86_64

The main non-straightforward thing is the extra `pypy` -> `pypy3` symlink that was necessary, since the new PyPy releases don't provide it, but portable-pypy did.