### PR TITLE
Dejan/pypy730

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,10 @@ the only supported platform is ``x86_64``.
 At the moment of writing, this image provide the following versions of
 PyPy:
 
+- PyPy2.7 7.3.0
+
+- PyPy3.6 7.3.0
+
 - PyPy2.7 7.2.0
 
 - PyPy3.6 7.2.0

--- a/docker/build_scripts_pypy/install_pypy.sh
+++ b/docker/build_scripts_pypy/install_pypy.sh
@@ -28,20 +28,17 @@ function install_one_pypy {
     if [ -f $outdir/bin/pypy3 ]; then
         # pypy -> pypy3
         if [ ! -f $outdir/bin/pypy ]; then
-
             ln -s pypy3 $outdir/bin/pypy
         fi
 
         # python -> pypy3
         if [ ! -f $outdir/bin/python ]; then
-
             ln -s pypy3 $outdir/bin/python
         fi
+
         # python3 -> pypy3
         if [ ! -f $outdir/bin/python3 ]; then
-
             # make python -> pypy3 link
-
             ln -s pypy3 $outdir/bin/python3
         fi
     fi

--- a/docker/build_scripts_pypy/install_pypy.sh
+++ b/docker/build_scripts_pypy/install_pypy.sh
@@ -18,13 +18,38 @@ function install_one_pypy {
     cd /opt/pypy
     tar xf $tarball
 
+    if [ -f $outdir/bin/pypy ]; then
+        # add a generic "python" symlink
+        ln -s pypy $outdir/bin/python
+        ln -s pypy $outdir/bin/python2
+    fi
+
+    # Since we mix pypy and Squeaky's portable binaries some links may already exist...
+    if [ -f $outdir/bin/pypy3 ]; then
+        # pypy -> pypy3
+        if [ ! -f $outdir/bin/pypy ]; then
+
+            ln -s pypy3 $outdir/bin/pypy
+        fi
+
+        # python -> pypy3
+        if [ ! -f $outdir/bin/python ]; then
+
+            ln -s pypy3 $outdir/bin/python
+        fi
+        # python3 -> pypy3
+        if [ ! -f $outdir/bin/python3 ]; then
+
+            # make python -> pypy3 link
+
+            ln -s pypy3 $outdir/bin/python3
+        fi
+    fi
+
     # rename the directory to something shorter like pypy2.7-7.1.1
     shortdir=$(get_shortdir $outdir/bin/pypy)
     mv "$outdir" "$shortdir"
     local pypy=$shortdir/bin/pypy
-
-    # add a generic "python" symlink
-    ln -s pypy $shortdir/bin/python
 
     # remove debug symbols
     rm $shortdir/bin/*.debug

--- a/docker/build_scripts_pypy/prefetch_pypy.sh
+++ b/docker/build_scripts_pypy/prefetch_pypy.sh
@@ -21,5 +21,7 @@ fetch_source pypy-7.2.0-linux_x86_64-portable.tar.bz2 "$URL/pypy-7.2.0"
 fetch_source pypy3.6-7.2.0-linux_x86_64-portable.tar.bz2 "$URL/pypy3.6-7.2.0"
 
 # pypy 7.3.0
-fetch_source pypy-7.3.0-linux_x86_64-portable.tar.bz2 "$URL/pypy-7.3.0"
-fetch_source pypy3.6-7.3.0-linux_x86_64-portable.tar.bz2 "$URL/pypy3.6-7.3.0"
+# Since 7.3.0 pypy is building portable binary packages, so we can safely grab them from there
+URL=https://bitbucket.org/pypy/pypy/downloads
+fetch_source pypy2.7-v7.3.0-linux64.tar.bz2 "$URL"
+fetch_source pypy3.6-v7.3.0-linux64.tar.bz2 "$URL"

--- a/docker/build_scripts_pypy/prefetch_pypy.sh
+++ b/docker/build_scripts_pypy/prefetch_pypy.sh
@@ -19,3 +19,7 @@ fetch_source pypy3.6-7.1.1-beta-linux_x86_64-portable.tar.bz2 "$BITBUCKET_URL"
 # pypy 7.2.0
 fetch_source pypy-7.2.0-linux_x86_64-portable.tar.bz2 "$URL/pypy-7.2.0"
 fetch_source pypy3.6-7.2.0-linux_x86_64-portable.tar.bz2 "$URL/pypy3.6-7.2.0"
+
+# pypy 7.3.0
+fetch_source pypy-7.3.0-linux_x86_64-portable.tar.bz2 "$URL/pypy-7.3.0"
+fetch_source pypy3.6-7.3.0-linux_x86_64-portable.tar.bz2 "$URL/pypy3.6-7.3.0"


### PR DESCRIPTION
This PR adds PyPy 7.3.0 to the Docker image and fixes the code to handle the mix of PyPy and Squeaky's binary packages.