### PR TITLE
Tag each docker build with a unique id, and push to dockerhub

### DIFF
--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
-docker login -u pypywheels -p $DOCKERPASS
 tag=pypywheels/manylinux2010-pypy_x86_64
+build_id=$(git show -s --format=%cd-%h --date=short $TRAVIS_COMMIT)
+
+docker login -u pypywheels -p $DOCKERPASS
+docker tag ${tag}:latest ${tag}:${build_id}
+docker push ${tag}:${build_id}
 docker push ${tag}:latest


### PR DESCRIPTION
Hi! I'm working on build determinism over on https://github.com/joerick/cibuildwheel/pull/256, and it'd be great to be able to refer to an individual docker image for a given release of cibuildwheel.

I've made similar PRs to pypa/manylinux - see https://github.com/pypa/manylinux/pull/440 - this PR is an adaptation of those to your deployment setup.

Thanks!