### PR TITLE
Updating 7.3.0 to 7.3.1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,9 +14,9 @@ the only supported platform is ``x86_64``.
 At the moment of writing, this image provide the following versions of
 PyPy:
 
-- PyPy2.7 7.3.0
+- PyPy2.7 7.3.1
 
-- PyPy3.6 7.3.0
+- PyPy3.6 7.3.1
 
 - PyPy2.7 7.2.0
 
@@ -45,21 +45,21 @@ also symlinked to ``/opt/python``. Moreover, each installation of PyPy
 contains also a ``python`` symlink.
 
 All the following commands are equivalent and run the PyPy 2.7, version
-7.3.0. You can use whatever fits best in your build system:
+7.3.1. You can use whatever fits best in your build system:
 
-- ``/opt/pypy/pypy2.7-7.3.0/bin/pypy``
+- ``/opt/pypy/pypy2.7-7.3.1/bin/pypy``
 
-- ``/opt/pypy/pypy2.7-7.3.0/bin/python``
+- ``/opt/pypy/pypy2.7-7.3.1/bin/python``
 
 - ``/opt/python/pp27-pypy_73/bin/pypy``
 
 - ``/opt/python/pp27-pypy_73/bin/python``
 
-Similarly, these are the commands to run PyPy 3.6, version 7.3.0:
+Similarly, these are the commands to run PyPy 3.6, version 7.3.1:
 
-- ``/opt/pypy/pypy3.6-7.3.0/bin/pypy``
+- ``/opt/pypy/pypy3.6-7.3.1/bin/pypy``
 
-- ``/opt/pypy/pypy3.6-7.3.0/bin/python``
+- ``/opt/pypy/pypy3.6-7.3.1/bin/python``
 
 - ``/opt/python/pp36-pypy36_pp73/bin/pypy``
 

--- a/README.rst
+++ b/README.rst
@@ -22,10 +22,6 @@ PyPy:
 
 - PyPy3.6 7.2.0
 
-- PyPy2.7 7.1.1
-
-- PyPy3.6 7.1.1
-
 Live example
 -------------
 

--- a/docker/build_scripts_pypy/install_pypy.sh
+++ b/docker/build_scripts_pypy/install_pypy.sh
@@ -40,7 +40,7 @@ function install_one_pypy {
     rm $shortdir/bin/*.debug
 
     # install and upgrade pip
-    $pypy -m ensurepip
+    $pypy -m ensurepip --default-pip
     $pypy -m pip install -U --require-hashes -r /build_scripts/requirements.txt
 
     local abi_tag=$($pypy /build_scripts/python-tag-abi-tag.py)

--- a/docker/build_scripts_pypy/prefetch_pypy.sh
+++ b/docker/build_scripts_pypy/prefetch_pypy.sh
@@ -22,6 +22,6 @@ fetch_source pypy3.6-7.1.1-beta-linux_x86_64-portable.tar.bz2 "$SQUEAKY_BITBUCKE
 fetch_source pypy-7.2.0-linux_x86_64-portable.tar.bz2 "$SQUEAKY_GITHUB_URL/pypy-7.2.0"
 fetch_source pypy3.6-7.2.0-linux_x86_64-portable.tar.bz2 "$SQUEAKY_GITHUB_URL/pypy3.6-7.2.0"
 
-# pypy 7.3.0
-fetch_source pypy2.7-v7.3.0-linux64.tar.bz2 "$URL"
-fetch_source pypy3.6-v7.3.0-linux64.tar.bz2 "$URL"
+# pypy 7.3.1
+fetch_source pypy2.7-v7.3.1-linux64.tar.bz2 "$URL"
+fetch_source pypy3.6-v7.3.1-linux64.tar.bz2 "$URL"

--- a/docker/build_scripts_pypy/prefetch_pypy.sh
+++ b/docker/build_scripts_pypy/prefetch_pypy.sh
@@ -3,7 +3,6 @@
 set -ex
 
 SOURCES=docker/sources
-SQUEAKY_BITBUCKET_URL=https://bitbucket.org/squeaky/portable-pypy/downloads # older releases
 SQUEAKY_GITHUB_URL=https://github.com/squeaky-pl/portable-pypy/releases/download # old releases
 URL=https://bitbucket.org/pypy/pypy/downloads # new releases
 
@@ -13,10 +12,6 @@ MY_DIR=$(dirname "${BASH_SOURCE[0]}")
 
 [ -d "$SOURCES" ] || mkdir "$SOURCES"
 cd "$SOURCES"
-
-# pypy 7.1.1
-fetch_source pypy-7.1.1-linux_x86_64-portable.tar.bz2 "$SQUEAKY_BITBUCKET_URL"
-fetch_source pypy3.6-7.1.1-beta-linux_x86_64-portable.tar.bz2 "$SQUEAKY_BITBUCKET_URL"
 
 # pypy 7.2.0
 fetch_source pypy-7.2.0-linux_x86_64-portable.tar.bz2 "$SQUEAKY_GITHUB_URL/pypy-7.2.0"


### PR DESCRIPTION
`pypy -m ensurepip --default-pip` is necessary since `pip` is already the version specified in `requirements.txt` and doesn't update, whereas before, the update would also install the `pip` script next to the `pip3` and `pip3.6` scripts.

See https://hub.docker.com/r/yannickjadoul/manylinux2010-pypy_x86_64 and joerick/cibuildwheel#304 for a temporary fork and cibuildwheel's test suite successfully using it.