### PR TITLE
improve size by not having tgz in the image

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,5 +4,4 @@
 set -ex
 
 TAG=pypywheels/manylinux2010-pypy_x86_64
-docker/build_scripts_pypy/prefetch_pypy.sh
 docker build --rm -t $TAG:latest -f docker/Dockerfile-x86_64 docker/

--- a/docker/Dockerfile-x86_64
+++ b/docker/Dockerfile-x86_64
@@ -1,9 +1,11 @@
 FROM quay.io/pypa/manylinux2010_x86_64
 LABEL maintainer="Antonio Cuni"
 
-COPY sources /
 COPY build_scripts /build_scripts
 COPY build_scripts_pypy /build_scripts_pypy
-RUN bash build_scripts_pypy/install_pypy.sh && rm -rf build_scripts*
+RUN : \
+    && build_scripts_pypy/prefetch_pypy.sh \
+    && build_scripts_pypy/install_pypy.sh \
+    && rm -rf /sources /build_scripts*
 
 CMD ["/bin/bash"]

--- a/docker/build_scripts_pypy/install_pypy.sh
+++ b/docker/build_scripts_pypy/install_pypy.sh
@@ -47,7 +47,7 @@ function install_one_pypy {
     ln -s /opt/pypy/$shortdir /opt/python/${abi_tag}
 }
 
-for TARBALL in /pypy*.tar.bz2
+for TARBALL in /sources/pypy*.tar.bz2
 do
     install_one_pypy "$TARBALL"
     rm "$TARBALL"

--- a/docker/build_scripts_pypy/prefetch_pypy.sh
+++ b/docker/build_scripts_pypy/prefetch_pypy.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-SOURCES=docker/sources
+SOURCES=/sources
 SQUEAKY_GITHUB_URL=https://github.com/squeaky-pl/portable-pypy/releases/download # old releases
 URL=https://downloads.python.org/pypy # new releases
 
@@ -10,7 +10,7 @@ URL=https://downloads.python.org/pypy # new releases
 MY_DIR=$(dirname "${BASH_SOURCE[0]}")
 . $MY_DIR/../build_scripts/build_utils.sh
 
-[ -d "$SOURCES" ] || mkdir "$SOURCES"
+mkdir -p "$SOURCES"
 cd "$SOURCES"
 
 # pypy 7.2.0


### PR DESCRIPTION
I noticed that the image size was a bit large so I looked into why that is

There's 1.04 GB from the base image so not much that can be improved there -- however I noticed that the .tgz sources are in the image so they're essentially bloat.

Docker is a layered filesystem so if you add contents in a layer it will live with the image forever (even if you delete it in a future layer, actually deleting it in a future layer makes the image slightly larger since deletion is implemented via whiteout files)

So I moved the source acquisition inside the layer where the pythons are installed and this reduced the overhead disk usage pretty dramatically.

Here's the docker history from the current image which is on dockerhub:

```
$ docker history docker.io/pypywheels/manylinux2010-pypy_x86_64
ID            CREATED        CREATED BY                                     SIZE     COMMENT
8373e8655e34  2 months ago   /bin/sh -c #(nop)  CMD ["/bin/bash"]           0 B      
<missing>     2 months ago   /bin/sh -c bash build_scripts_pypy/install...  450 MB   
<missing>     2 months ago   /bin/sh -c #(nop) COPY dir:83d196df7353244...  6.14 kB  
<missing>     2 months ago   /bin/sh -c #(nop) COPY dir:b6cf88d344488c5...  534 kB   
<missing>     2 months ago   /bin/sh -c #(nop) COPY dir:4ec5065aa04411f...  133 MB   
<missing>     2 months ago   /bin/sh -c #(nop)  LABEL maintainer=Antoni...  0 B      
...
```

Note that the COPY at the bottom is the `COPY sources /` that I removed -- and this 133MB lives with the image permanently

In my adjusted version, this is what those layers look like now:

```
$ docker history test
ID            CREATED        CREATED BY                                     SIZE     COMMENT
0dd9e8404836  4 minutes ago  /bin/sh -c #(nop) CMD ["/bin/bash"]            0 B      
<missing>     4 minutes ago  /bin/sh -c :     && build_scripts_pypy/pre...  450 MB   
f7782c9f490e  6 minutes ago  /bin/sh -c #(nop) COPY dir:3b7c4e3c9c0b411...  6.14 kB  
7f269f24df66  7 minutes ago  /bin/sh -c #(nop) COPY dir:eeea7d90789cc10...  534 kB   
1d63db00a9ae  7 minutes ago  /bin/sh -c #(nop) LABEL maintainer="Antoni...  0 B 
...
```

so I essentially reduced the image size by 133MB!

