### PR TITLE
Update to PyPy 7.3.5

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,9 +14,9 @@ the only supported platform is ``x86_64``.
 At the moment of writing, this image provide the following versions of
 PyPy:
 
-- PyPy2.7 7.3.4
+- PyPy2.7 7.3.5
 
-- PyPy3.7 7.3.4
+- PyPy3.7 7.3.5
 
 - PyPy3.6 7.3.3
 
@@ -43,21 +43,21 @@ also symlinked to ``/opt/python``. Moreover, each installation of PyPy
 contains also a ``python`` symlink.
 
 All the following commands are equivalent and run the PyPy 2.7, version
-7.3.4. You can use whatever fits best in your build system:
+7.3.5. You can use whatever fits best in your build system:
 
-- ``/opt/pypy/pypy2.7-7.3.4/bin/pypy``
+- ``/opt/pypy/pypy2.7-7.3.5/bin/pypy``
 
-- ``/opt/pypy/pypy2.7-7.3.4/bin/python``
+- ``/opt/pypy/pypy2.7-7.3.5/bin/python``
 
 - ``/opt/python/pp27-pypy_73/bin/pypy``
 
 - ``/opt/python/pp27-pypy_73/bin/python``
 
-Similarly, these are the commands to run PyPy 3.7, version 7.3.4:
+Similarly, these are the commands to run PyPy 3.7, version 7.3.5:
 
-- ``/opt/pypy/pypy3.7-7.3.4/bin/pypy``
+- ``/opt/pypy/pypy3.7-7.3.5/bin/pypy``
 
-- ``/opt/pypy/pypy3.7-7.3.4/bin/python``
+- ``/opt/pypy/pypy3.7-7.3.5/bin/python``
 
 - ``/opt/python/pp37-pypy37_pp73/bin/pypy``
 

--- a/docker/build_scripts_pypy/prefetch_pypy.sh
+++ b/docker/build_scripts_pypy/prefetch_pypy.sh
@@ -20,6 +20,6 @@ fetch_source pypy3.6-7.2.0-linux_x86_64-portable.tar.bz2 "$SQUEAKY_GITHUB_URL/py
 # pypy 7.3.3 (3.6 only)
 fetch_source pypy3.6-v7.3.3-linux64.tar.bz2 "$URL"
 
-# pypy 7.3.4
-fetch_source pypy2.7-v7.3.4-linux64.tar.bz2 "$URL"
-fetch_source pypy3.7-v7.3.4-linux64.tar.bz2 "$URL"
+# pypy 7.3.5
+fetch_source pypy2.7-v7.3.5-linux64.tar.bz2 "$URL"
+fetch_source pypy3.7-v7.3.5-linux64.tar.bz2 "$URL"


### PR DESCRIPTION
Quick, minor update, but with a twist: this time, we don't really need it for cibuildwheel, as https://github.com/pypa/manylinux/pull/1103 happened.

So, question: do you still wish to receive future PRs with updates for the image?

The new manylinux images only contain PyPy 7.3.5 Python 3.7, right now. So, this repository/image contains still contains extra:
- Python 2.7-compatible PyPy versions.
- The previous 7.2.x PyPy versions (i.e., to support the previous ABI).
- PyPy 7.3.3, Python 3.6.

If none of these are still necessary, or it is good enough to have these older Docker images for now, having everything in PyPA's manylinux images is of course a great advantage. If you would like to keep these images as well, then I can do my best to remind myself and keep providing PRs (and test then with cibuildwheel).